### PR TITLE
Add missing content on single "privacy-sandbox" pages

### DIFF
--- a/site/en/privacy-sandbox/measure-digital-ads/index.njk
+++ b/site/en/privacy-sandbox/measure-digital-ads/index.njk
@@ -16,6 +16,15 @@ sections:
     - url: /docs/privacy-sandbox/attribution-reporting-updates
       title: API updates
       description: A quick reference to how the proposal has changed to address community feedback.
+  related_measurement:
+    - url: /docs/privacy-sandbox/summary-reports
+      title: Summary reports overview
+    - url: /docs/privacy-sandbox/aggregation-service
+      title: Aggregation service
+    - url: /docs/privacy-sandbox/attribution-reporting-data-clearing
+      title: Impact of user-initiated data clearing
+    - url: /docs/privacy-sandbox/attribution-reporting-debugging/
+      title: Debug Attribution Reporting
 ---
 
 {% from 'macros/cards/hero-card-wide.njk' import heroCardWide with context %}

--- a/site/en/privacy-sandbox/prevent-covert-tracking/index.njk
+++ b/site/en/privacy-sandbox/prevent-covert-tracking/index.njk
@@ -7,6 +7,9 @@ sections:
     - url: /docs/privacy-sandbox/ip-protection
     - url: /docs/privacy-sandbox/privacy-budget
     - url: /docs/privacy-sandbox/bounce-tracking-mitigations
+  prevent_covert_tracking_useragent:
+    - url: /docs/privacy-sandbox/user-agent
+    - url: /docs/privacy-sandbox/user-agent/snippets
 ---
 
 {% from 'macros/cards/hero-card-wide.njk' import heroCardWide with context %}


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds missing sections on covert tracking and digital ads pages