### PR TITLE
Docs/remove missing images

### DIFF
--- a/site/_includes/macros/landing-deco.njk
+++ b/site/_includes/macros/landing-deco.njk
@@ -24,16 +24,6 @@
           <a class="landing-deco__learn-more color-{{color}}-medium" href="{{learnMore.link}}">{{ learnMore.title or 'i18n.landing.sections.learn_more'| i18n }}</a>
         {% endif %}
       </div>
-      {% if imgSrc %}
-        <div class="display-flex justify-content-center align-content-center gap-top-600 masonry:gap-top-600 md-only">
-          {% Img
-            src=imgSrc,
-            alt=imgAlt,
-            width=imgWidth,
-            height=imgHeight
-          %}
-        </div>
-      {% endif %}
     </div>
   </div>
 {% endmacro %}

--- a/site/en/privacy-sandbox/prevent-covert-tracking/index.njk
+++ b/site/en/privacy-sandbox/prevent-covert-tracking/index.njk
@@ -5,11 +5,21 @@ description: 'A series of proposals to satisfy cross-site use cases without thir
 sections:
   prevent_covert_tracking:
     - url: /docs/privacy-sandbox/ip-protection
+      title : IP Protection
+      description: "A proposal to protect users' IP addresses from being exposed to third-party content."
     - url: /docs/privacy-sandbox/privacy-budget
+      title : Privacy Budget
+      description: "A proposal to limit the amount of individual user data exposed to sites to prevent covert tracking."
     - url: /docs/privacy-sandbox/bounce-tracking-mitigations
+      title : Bounce Tracking Mitigations
+      description: "Reduce or eliminate the ability of bounce tracking to recognize people across contexts."
   prevent_covert_tracking_useragent:
     - url: /docs/privacy-sandbox/user-agent
+      title : User-Agent Reduction
+      description: "User-Agent reduction limits passively shared browser data to reduce the volume of sensitive information which leads to fingerprinting. The reduction is now complete."
     - url: /docs/privacy-sandbox/user-agent/snippets
+      title : User-Agent Snippets
+      description: "Test your sites and services against the reduced Chrome user-agent with regular expressions."
 ---
 
 {% from 'macros/cards/hero-card-wide.njk' import heroCardWide with context %}

--- a/site/en/privacy-sandbox/strengthen-privacy-boundaries/index.njk
+++ b/site/en/privacy-sandbox/strengthen-privacy-boundaries/index.njk
@@ -5,11 +5,19 @@ description: 'A series of proposals to satisfy cross-site use cases without thir
 sections:
   strengthen_privacy_boundaries:
     - url: /docs/privacy-sandbox/chips
+      title : Cookies Having Independent Partitioned State (CHIPS)
+      description : Allow developers to opt-in a cookie to "partitioned" storage, with a separate cookie jar per top-level site. Partitioned cookies can be set by a third-party service, but only read within the context of the top-level site where they were initially set.
     - url: /docs/privacy-sandbox/permissions-policy
     - url: /docs/privacy-sandbox/fedcm
+      title : Federated Credential Management API
+      description : A web platform API that allows users to login to websites with their federated accounts in a manner compatible with improvements to browser privacy.
     - url: /docs/privacy-sandbox/first-party-sets
     - url: /docs/privacy-sandbox/fenced-frame
+      title : Fenced Frames
+      description : Securely embed content onto a page without sharing cross-site data.
     - url: /docs/privacy-sandbox/storage-partitioning
+      title : Storage Partitioning
+      description : To prevent certain types of side-channel cross-site tracking, Chrome is partitioning storage and communications APIs in third-party contexts.
 ---
 
 {% from 'macros/cards/hero-card-wide.njk' import heroCardWide with context %}


### PR DESCRIPTION
Removes Broken images from landing macro.

Also fixes covert tracking landing page and strengthen privacy boundaries in the privacy sandbox landing page.